### PR TITLE
Avoid the round option for project option

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -685,9 +685,10 @@ class EnvBatch(EnvBase):
             else:
                 rval = val
 
-            # We don't want floating-point data (ignore anything else)
-            if str(rval).replace(".", "", 1).isdigit():
-                rval = int(round(float(rval)))
+            if flag != "-P":
+                # We don't want floating-point data (ignore anything else)
+                if str(rval).replace(".", "", 1).isdigit():
+                    rval = int(round(float(rval)))
 
             # need a correction for tasks per node
             if flag == "-n" and rval <= 0:


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Avoid the number rounding in the project name option

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

https://github.com/CMCC-Foundation/cime/issues/3

User interface changes?:

Update gh-pages html (Y/N)?:
