### PR TITLE
Update nodes value for both zeus and juno

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -424,9 +424,9 @@ def _case_setup_impl(
 
         # Record env information
         env_module = case.get_env("mach_specific")
-        if mach == "zeus":
+        if mach == "zeus" or "juno":
             overrides = env_module.get_overrides_nodes(case)
-            logger.debug("Updating Zeus nodes {}".format(overrides))
+            logger.debug("Updating nodes {}".format(overrides))
         env_module.make_env_mach_specific_file("sh", case)
         env_module.make_env_mach_specific_file("csh", case)
         if not non_local:


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

This option is needed by zeus and juno in order to automatically update the value of I_MPI_HYDRA_BRANCH_COUNT with the effective number of nodes 


Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
