### PR TITLE
Add quotes to command arguments in replay.sh

### DIFF
--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -85,6 +85,75 @@ class TestCase(unittest.TestCase):
         self.tempdir = tempfile.TemporaryDirectory()
 
     @mock.patch("CIME.case.case.Case.read_xml")
+    def test_fix_sys_argv_quotes(self, read_xml):
+        input_data = ["./xmlquery", "--val", "PIO"]
+        expected_data = ["./xmlquery", "--val", "PIO"]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            make_valid_case(tempdir)
+
+            with Case(tempdir) as case:
+                output_data = case.fix_sys_argv_quotes(input_data)
+
+        assert output_data == expected_data
+
+    @mock.patch("CIME.case.case.Case.read_xml")
+    def test_fix_sys_argv_quotes_incomplete(self, read_xml):
+        input_data = ["./xmlquery", "--val"]
+        expected_data = ["./xmlquery", "--val"]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            make_valid_case(tempdir)
+
+            with Case(tempdir) as case:
+                output_data = case.fix_sys_argv_quotes(input_data)
+
+        assert output_data == expected_data
+
+    @mock.patch("CIME.case.case.Case.read_xml")
+    def test_fix_sys_argv_quotes_val(self, read_xml):
+        input_data = ["./xmlquery", "--val", "-test"]
+        expected_data = ["./xmlquery", "--val", "-test"]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            make_valid_case(tempdir)
+
+            with Case(tempdir) as case:
+                output_data = case.fix_sys_argv_quotes(input_data)
+
+        assert output_data == expected_data
+
+    @mock.patch("CIME.case.case.Case.read_xml")
+    def test_fix_sys_argv_quotes_val_quoted(self, read_xml):
+        input_data = ["./xmlquery", "--val", " -nlev 267 "]
+        expected_data = ["./xmlquery", "--val", '" -nlev 267 "']
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            make_valid_case(tempdir)
+
+            with Case(tempdir) as case:
+                output_data = case.fix_sys_argv_quotes(input_data)
+
+        assert output_data == expected_data
+
+    @mock.patch("CIME.case.case.Case.read_xml")
+    def test_fix_sys_argv_quotes_kv(self, read_xml):
+        input_data = ["./xmlquery", "CAM_CONFIG_OPTS= -nlev 267", "OTHER_OPTS=-test"]
+        expected_data = [
+            "./xmlquery",
+            'CAM_CONFIG_OPTS=" -nlev 267"',
+            "OTHER_OPTS=-test",
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            make_valid_case(tempdir)
+
+            with Case(tempdir) as case:
+                output_data = case.fix_sys_argv_quotes(input_data)
+
+        assert output_data == expected_data
+
+    @mock.patch("CIME.case.case.Case.read_xml")
     @mock.patch("sys.argv", ["/src/create_newcase", "--machine", "docker"])
     @mock.patch("time.strftime", return_value="00:00:00")
     @mock.patch("socket.getfqdn", return_value="host1")


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Changes add quotes to command arguments in replay.sh

These changes have been taken from commit 9333a6f of ESMCI/cime
that fixes issue https://github.com/ESMCI/cime/issues/4361

Test suite:

tested on a two-day and one-resubmit coupled simulation

Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
