### PR TITLE
Update config_machines schemas for command option, needed by WW3

### DIFF
--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -253,7 +253,7 @@
   </xs:element>
   <xs:element name="command">
     <xs:complexType mixed="true">
-      <xs:attribute ref="name" use="required"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="environment_variables">


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Change the number of attributes that can be used in the command value of the config_machines as described in the xml_schemas.

This change is needed for the WW3 test simulations.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
